### PR TITLE
fix: update console command execute() method signatures…

### DIFF
--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -36,7 +36,7 @@ class BenchmarkCommand extends Command
      * @param OutputInterface $output
      * @return int|void|null
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->testSimpleCount($output);
         $this->testGroupCount($output);


### PR DESCRIPTION
This pull request makes a minor update to the `BenchmarkCommand` class, specifically improving type safety by updating the return type of the `execute` method.

* Updated the `execute` method in `BenchmarkCommand` (`src/Command/BenchmarkCommand.php`) to explicitly declare an `int` return type, enhancing type safety and clarity.

These changes ensure the package remains compatible with the latest Magento release and adheres to the updated interface requirements.
The changes are backward compatible, it works fine on old Magento versions where is a signature doesn't have return type:

protected function execute(InputInterface $input, OutputInterface $output)